### PR TITLE
Fix missing webview provider crash on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -147,7 +147,7 @@ public class ForwardingCookieHandler extends CookieHandler {
             && exception
                 .getClass()
                 .getCanonicalName()
-                .equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
+                .contains("MissingWebViewPackageException")) {
           return null;
         } else {
           throw exception;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I applied the changes requested in this PR: https://github.com/facebook/react-native/pull/29089

We upgraded to RN 0.62.2 on our latest release and started to see again the "Failed to load WebView provider: No WebView installed" (see below for Crashlytics screenshot)

![image](https://user-images.githubusercontent.com/870365/131935283-033fbd44-5a3b-49b0-bd25-3d6733f22040.png)

This crash had been fixed by https://github.com/facebook/react-native/pull/24533 but https://github.com/facebook/react-native/pull/26189 (added in 0.62) reverted the fix

Indeed the exception raised in Crashlytics is actually a `AndroidRuntimeException` and `MissingWebViewPackageException` is only part of the message.

For instance, in the screenshot above, the exception message is `android.webkit.WebViewFactory$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed`

Now these crashes are quite tricky to reproduce, so to be on the safe side, I'm filtering out all exceptions containing `WebView` as suggested by @thorbenprimke on the original fix.

If my reasoning is correct, it should fix @siddhantsoni 's issue as well, since `WebView` is included in `MissingWebViewPackageException`
But following that reasoning, I am not sure https://github.com/facebook/react-native/pull/26189 fixed @siddhantsoni 's issue, so @siddhantsoni if you could check that this PR also fixes your issue, that would be great!

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[Android] [Fixed] - Fix missing WebView provider crash in ForwardingCookieHandler

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan

I created a version of react native with this patch applied

```
"react-native": "almouro/react-native#release/062-2-fix-missing-webview-provider"
```

Before the fix ~0.1% of our users were impacted on Android, no new crashes have occurred after the update.

This is putting back what was already in place and working for us, but making the check wider to catch more errors.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
